### PR TITLE
prefer capturing `this` as `self`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,14 +1058,14 @@
     this._firstName = 'Panda';
     ```
 
-  - When saving a reference to `this` use `_this`.
+  - When saving a reference to `this` use `self`.
 
     ```javascript
     // bad
     function() {
-      var self = this;
+      var _this = this;
       return function() {
-        console.log(self);
+        console.log(_this);
       };
     }
 
@@ -1079,9 +1079,9 @@
 
     // good
     function() {
-      var _this = this;
+      var self = this;
       return function() {
-        console.log(_this);
+        console.log(self);
       };
     }
     ```


### PR DESCRIPTION
I'm not a big fan of `_this`. To me, `_` typically denotes something private with respect to the externally visible API. That has no bearing on the capturing of context and therefore its a weak convention. I'd prefer to use `self`. 