### PR TITLE
Change to one variable per `var`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@
     + `undefined`
 
     ```javascript
-    var foo = 1,
-        bar = foo;
+    var foo = 1;
+    var bar = foo;
 
     bar = 9;
 
@@ -145,9 +145,9 @@
   - When you need to copy an array use Array#slice. [jsPerf](http://jsperf.com/converting-arguments-to-an-array/7)
 
     ```javascript
-    var len = items.length,
-        itemsCopy = [],
-        i;
+    var len = items.length;
+    var itemsCopy = [];
+    var i;
 
     // bad
     for (i = 0; i < len; i++) {
@@ -210,10 +210,10 @@
   - When programmatically building up a string, use Array#join instead of string concatenation. Mostly for IE: [jsPerf](http://jsperf.com/string-vs-array-concat/2).
 
     ```javascript
-    var items,
-        messages,
-        length,
-        i;
+    var items;
+    var messages;
+    var length;
+    var i;
 
     messages = [{
       state: 'success',
@@ -360,40 +360,40 @@
     var superPower = new SuperPower();
     ```
 
-  - Use one `var` declaration for multiple variables and declare each variable on a newline.
+  - Use one `var` declaration for each variable and declare each variable on a newline.
 
     ```javascript
     // bad
-    var items = getItems();
-    var goSportsTeam = true;
-    var dragonball = 'z';
-
-    // good
     var items = getItems(),
         goSportsTeam = true,
         dragonball = 'z';
+
+    // good
+    var items = getItems();
+    var goSportsTeam = true;
+    var dragonball = 'z';
     ```
 
   - Declare unassigned variables last. This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.
 
     ```javascript
     // bad
-    var i, len, dragonball,
-        items = getItems(),
-        goSportsTeam = true;
+    var i, len, dragonball;
+    var items = getItems();
+    var goSportsTeam = true;
 
     // bad
-    var i, items = getItems(),
-        dragonball,
-        goSportsTeam = true,
-        len;
+    var i, items = getItems();
+    var dragonball;
+    var goSportsTeam = true;
+    var len;
 
     // good
-    var items = getItems(),
-        goSportsTeam = true,
-        dragonball,
-        length,
-        i;
+    var items = getItems();
+    var goSportsTeam = true;
+    var dragonball;
+    var length;
+    var i;
     ```
 
   - Assign variables at the top of their scope. This helps avoid issues with variable declaration and assignment hoisting related issues.
@@ -830,14 +830,18 @@
 
     ```javascript
     // bad
-    var once
+    var story = [
+        once
       , upon
-      , aTime;
+      , aTime
+      ];
 
     // good
-    var once,
+    var story = [
+        once,
         upon,
-        aTime;
+        aTime
+      ];
 
     // bad
     var hero = {

--- a/linters/jscsrc
+++ b/linters/jscsrc
@@ -1,5 +1,7 @@
 {
   "preset": "airbnb",
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "requireMultipleVarDecl": null,
   "disallowKeywordsOnNewLine": ["else", "catch"],
   "disallowTrailingWhitespace": "ignoreEmptyLines",
   "disallowQuotedKeysInObjects": "allButReserved",


### PR DESCRIPTION
## What
I've been thinking about this and would like to propose we change the rule from:

```javascript
var a = 'something',
    b = 'something else',
    c, d;
```

to

```javascript
var a = 'something';
var b = 'something else';
var c, d;
```

## Why

1. It's easier to rearrange variable declarations (ie. because you want to change `a` to `var a = b + '!';`)

2. Indentation gets better

  ```javascript
  //before
  var b = {
      c: 'Foo!'
    },
    c = 'Hello',
    d;
  d = {
    e: 'Oh oh'
  };

  //after
  var b = {
    c: 'Foo!'
  };
  var c = 'Hello';
  var d;
  d = {
    e: 'Oh yeah!'
  };
  ```
  See also: single line comments, 

3. As we move towards ES6 we get `let` and `const`, so we're going to need multiple "blocks" of variables anyway.

4. This wouldn't preclude code such as ` var { Publisher, Subscriber } = OT;`