### PR TITLE
Prefer factories over prototype + this

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,10 @@
 
     ```javascript
     // bad
-    superPower = new SuperPower();
+    superPower = createSuperPower();
 
     // good
-    var superPower = new SuperPower();
+    var superPower = createSuperPower();
     ```
 
   - Use one `var` declaration for multiple variables and declare each variable on a newline.
@@ -597,7 +597,7 @@
 
 ## Blocks
 
-  - Use braces with all multi-line blocks.
+  - Use braces with all blocks.
 
     ```javascript
     // bad
@@ -1205,31 +1205,47 @@
 
     ```javascript
     // bad
-    Jedi.prototype.jump = function() {
-      this.jumping = true;
-      return true;
+    var createJedi = function() {
+      var api = {};
+      var jumping = false;
+      var height;
+
+      api.jump = function() {
+        jumping = true;
+        return true;
+      };
+  
+      api.setHeight = function(newHeight) {
+        height = newHeight;
+      };
+      
+      return api;
     };
 
-    Jedi.prototype.setHeight = function(height) {
-      this.height = height;
-    };
-
-    var luke = new Jedi();
+    var luke = createJedi();
     luke.jump(); // => true
     luke.setHeight(20) // => undefined
 
     // good
-    Jedi.prototype.jump = function() {
-      this.jumping = true;
-      return this;
+    var createJedi = function() {
+      var api = {};
+      var jumping = false;
+      var height;
+
+      api.jump = function() {
+        jumping = true;
+        return api;
+      };
+  
+      api.setHeight = function(newHeight) {
+        height = newHeight;
+        return api;
+      };
+      
+      return api;
     };
 
-    Jedi.prototype.setHeight = function(height) {
-      this.height = height;
-      return this;
-    };
-
-    var luke = new Jedi();
+    var luke = createJedi();
 
     luke.jump()
       .setHeight(20);
@@ -1301,18 +1317,18 @@
     !function(global) {
       'use strict';
 
-      var previousFancyInput = global.FancyInput;
+      var previousFancyInput = global.createFancyInput;
 
-      function FancyInput(options) {
-        this.options = options || {};
+      function createFancyInput(options) {
+        var options = options || {};
       }
 
-      FancyInput.noConflict = function noConflict() {
-        global.FancyInput = previousFancyInput;
-        return FancyInput;
+      createFancyInput.noConflict = function noConflict() {
+        global.createFancyInput = previousFancyInput;
+        return createFancyInput;
       };
 
-      global.FancyInput = FancyInput;
+      global.createFancyInput = createFancyInput;
     }(this);
     ```
 

--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,39 @@
 
 ## Constructors
 
-  - Assign methods to the prototype object, instead of overwriting the prototype with a new object. Overwriting the prototype makes inheritance impossible: by resetting the prototype you'll overwrite the base!
+  - Prefer factories over prototypes
+  
+    ```javascript
+    // bad
+    function Widget(name) {
+      this.privateField = 'Hello ';
+      this.name = name;
+    }
+    
+    Widget.prototype.publicMethod = function() {
+      return this.privateField + this.name + '!';
+    }
+    
+    var widget = new Widget('Testing');
+    
+    // good
+    var createWidget = function(name) {
+      var api = new (function Widget(){})();
+
+      var privateField = 'Hello ';
+    
+      api.publicMethod = function() {
+        return privateField + name + '!';
+      };
+    
+      return api;
+    }
+    
+    var widget = createWidget('Testing!');
+  ```
+  - Use prototypes only when an extremely large number of objects will be created (think in the millions)
+  - You're probably better off not using prototype then either.
+  - If you are using it though, assign methods to the prototype object, instead of overwriting the prototype with a new object. Overwriting the prototype makes inheritance impossible: by resetting the prototype you'll overwrite the base!
 
     ```javascript
     function Jedi() {
@@ -1207,17 +1239,20 @@
   - It's okay to write a custom toString() method, just make sure it works successfully and causes no side effects.
 
     ```javascript
-    function Jedi(options) {
+    var createJedi = function(options) {
+      var api = new (function Jedi() { })();
       options || (options = {});
-      this.name = options.name || 'no name';
-    }
-
-    Jedi.prototype.getName = function getName() {
-      return this.name;
-    };
-
-    Jedi.prototype.toString = function toString() {
-      return 'Jedi - ' + this.getName();
+      var name = options.name || 'no name';
+        
+      api.getName = function getName() {
+        return name;
+      };
+      
+      api.toString = function toString() {
+        return 'Jedi - ' + name;
+      };
+      
+      return api;
     };
     ```
 


### PR DESCRIPTION
We don't use the prototype much, and generally prefer the pattern of calling a method and being given an object back. Let's formalise that.

## What

```javascript
// before
function Widget(name) {
  this.privateField = 'Hello ';
  this.name = name;
}
var foo = new Thing();

// after
var createWidget = function(name) {
  var api = new (function Widget(){})();

  var privateField = 'Hello ';
  api.name = name;

  return api;
}
var foo = createThing();
```

## Why

1. Using thew `new` keyword and an object prototype makes it harder to separate internal properties and functions from intentionally external APIs
2. We typically do this anyway
3. We avoid using `this` in new code anyway

## Up for debate

1. `var api...` The name of this variable. In #1 @aoberoi argued for it being `self`. I'd like us to make a decision on that name (keeping in mind that it will apply for this one too)

2. `var api = new (function Widget(){})();` This may help us in debuggers, but is it worth the overhead? Should this be noted as an optional suggestion? Only for publicly returned objects?
