### PR TITLE
The variable self has become a new special value referring to the global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,14 +1062,14 @@
     this._firstName = 'Panda';
     ```
 
-  - When saving a reference to `this` use `self`.
+  - When saving a reference to `this` use `_this` as it's coherent with a _private this_ and `self` has become a [special value](https://developer.mozilla.org/en-US/docs/Web/API/Window/self).
 
     ```javascript
     // bad
     function() {
-      var _this = this;
+      var self = this;
       return function() {
-        console.log(_this);
+        console.log(self);
       };
     }
 
@@ -1083,9 +1083,9 @@
 
     // good
     function() {
-      var self = this;
+      var _this = this;
       return function() {
-        console.log(self);
+        console.log(_this);
       };
     }
     ```


### PR DESCRIPTION
The variable self has become a new special value referring to the global scope [1] so in case of windows it is window and for workers, it is the WorkerGlobalScope. Replace with _this makes sense and coherent with other guidelines as it stands for something like a private this.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Window/self